### PR TITLE
Increase the LoadingEffect duration by 200ms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ const App = () => {
     setLoading(true);
     setTimeout(() => {
       setLoading(false);
-    }, 3800);
+    }, 4000);
   }, []);
 
   return (

--- a/src/components/LoadingEffect/loading_effect.css
+++ b/src/components/LoadingEffect/loading_effect.css
@@ -8,7 +8,7 @@
   justify-content: center;
   z-index: 100;
   animation: acme var(--ease-in-out-cubic) var(--ms500) both;
-  animation-delay: calc(var(--s3) + var(--ms300));
+  animation-delay: calc(var(--s3) + var(--ms500));
   box-shadow: 0 1rem 3.25rem var(--neutral-450);
 }
 


### PR DESCRIPTION
This give the app up to 4s of delay while loading the most important assets.

It should be plenty of time for most connection types.