### PR TITLE
Move my Anchor components off

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,12 +40,12 @@ const App = () => {
         <div>
           <Nav />
           <main>
-            <AnchorLinks />
-            <AnchorMail />
             <Hero />
             <WhoAmI />
             <Projects />
             <Connect />
+            <AnchorLinks />
+            <AnchorMail />
             <Footer />
             <AnalyticsComponent />
           </main>


### PR DESCRIPTION
A11Y: since those are mostly decorations, when tabbing, they should not be one of the firsts elements in the order of selections