### PR TITLE
Increase image-box's top margin on smaller-screens

### DIFF
--- a/src/components/Hero/hero.css
+++ b/src/components/Hero/hero.css
@@ -201,7 +201,7 @@
   .hero .image-box {
     grid-row: 1;
     justify-content: center;
-    margin-top: 6.5em;
+    margin-top: 7rem;
   }
 
   .hero .text-box {


### PR DESCRIPTION
Previously, if the picture was tapped on, a small portion of the tag was overlapped by the navbar.